### PR TITLE
specs: Support JRuby using jruby-sqlite3 gem

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,6 @@ rvm:
   - ruby-2.0
   - ruby-2.1
   - ruby-2.2
+  - jruby-19mode
 
 sudo: false

--- a/Gemfile
+++ b/Gemfile
@@ -6,8 +6,9 @@ gem 'rake'
 group :development, :test do
   gem 'bundler', '>= 1.0.0'
   gem 'rspec'
-  gem 'sqlite3'
+  gem 'sqlite3', platform: :mri
+  gem 'jdbc-sqlite3', platform: :jruby
   gem 'faker'
   gem 'coveralls', require: false
-  gem 'jekyll', require: false
+  gem 'jekyll', require: false, platform: :mri
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -27,6 +27,7 @@ GEM
     http-cookie (1.0.2)
       domain_name (~> 0.5)
     i18n (0.7.0)
+    jdbc-sqlite3 (3.8.11.2)
     jekyll (2.5.3)
       classifier-reborn (~> 2.0)
       colorator (~> 0.1)
@@ -51,6 +52,7 @@ GEM
     jekyll-watch (1.3.0)
       listen (~> 3.0)
     json (1.8.3)
+    json (1.8.3-java)
     kramdown (1.9.0)
     liquid (2.6.3)
     listen (3.0.3)
@@ -104,18 +106,24 @@ GEM
       parslet (~> 1.5.0)
     unf (0.1.4)
       unf_ext
+    unf (0.1.4-java)
     unf_ext (0.0.7.1)
     yajl-ruby (1.2.1)
 
 PLATFORMS
+  java
   ruby
 
 DEPENDENCIES
   bundler (>= 1.0.0)
   coveralls
   faker
+  jdbc-sqlite3
   jekyll
   rake
   rspec
   sequel (~> 4.0)
   sqlite3
+
+BUNDLED WITH
+   1.10.6

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -26,7 +26,13 @@ RSpec.configure do |config|
 
   Sequel.extension :seed
 
-  DB = Sequel.sqlite
+  dsn = if RUBY_PLATFORM == 'java'
+    'jdbc:sqlite::memory:'
+  else
+    'sqlite:/'
+  end
+
+  DB = Sequel.connect(dsn)
 
   DB.create_table(:spec_models) do
     primary_key :id, :auto_increment => true


### PR DESCRIPTION
This changes makes the test suite run and pass on my machine with JRuby 1.7.23.

The library has no run-time dependencies on MRI, and I don't see why it could not skip test-time dependencies, as well.

(Publishing the website is a maintainer concern, so I just set it to be MRI-only.)